### PR TITLE
Allow service accounts to mint OAuth tokens

### DIFF
--- a/managed-service-accounts-tdd.md
+++ b/managed-service-accounts-tdd.md
@@ -245,7 +245,54 @@ Design directions that surfaced during this work but are not part of the MVP. Th
 
 A future enhancement could allow the built-in `elastic/kibana` account to run-as a managed service account for workload execution. Kibana would authenticate with its own credential and execute with the managed account's identity and live-resolved roles. This would be a third execution option alongside direct bearer-token use and grant-based API keys, with two attractive properties: no long-lived managed-account token needs to be distributed to (or stored by) Kibana at all, and run-as preserves both identities in audit (authenticated by `elastic/kibana`, effective user the managed account), which is arguably the strongest audit story of the three options.
 
-Elasticsearch currently blocks this in two places. Service-account authentications can neither initiate run-as (an `Authentication` consistency rule) nor serve as run-as targets (target resolution goes through user lookup realms, which do not cover the `_service_account` realm). An impersonation model would also need to answer who may run-as which accounts: `run_as` patterns in role descriptors match principal names, so the fixed `elastic/kibana` descriptor could carry a pattern covering managed namespaces while excluding `elastic/*`, which is feasible since built-in descriptors are source-controlled.
+Elasticsearch currently blocks this in two places. A service account cannot initiate run-as, and a service account cannot be a run-as target: impersonation lookup only considers ordinary users, not identities in the `_service_account` realm. Both gates would lift for this feature.
+
+The authorization model is the part that needs a deliberate design. Today's run-as is caller-only: Elasticsearch checks the authenticating principal's role `run_as` patterns against the target name, and the target has no say. Putting a managed-namespace pattern on the built-in `elastic/kibana` role (covering every non-`elastic/*` name) would make the Kibana service token a universal impersonation key for the managed-account namespace. That is privilege escalation. `elastic/kibana` is `kibana_system`, which is broad but closed: it is not `manage_security` and not unrestricted `all`. Managed accounts may be assigned any role, including reserved roles. A name-pattern grant would let a stolen or compromised Kibana token inhabit any of them, including an account an admin later assigns `superuser`. It is also strictly more powerful than the other two execution paths, which require possession of the target's credential (`grant_api_key` still needs the target's access token or password). Excluding `elastic/*` only protects other built-in service accounts; it does not bound the privileges of `acme/*`.
+
+The ACL therefore lives on the target account, as a default-deny allowlist of impersonator principals, with a small caller-side capability rather than a name wildcard.
+
+#### Target consent: `run_as_from`
+
+```
+PUT /_security/service/acme/billing-workflow
+{
+  "roles": ["billing_read", "connector_caller"],
+  "enabled": true,
+  "run_as_from": ["elastic/kibana"]
+}
+```
+
+`run_as_from` is an optional list of exact principals who may impersonate this account. Absent or empty means nobody may: fail closed, and the state of every account created before the field exists. GET returns the field. The name is deliberately not `run_as`; on a role descriptor that means "who I may inhabit," and reusing it here would invert the meaning on a different document type. The security index already maps `run_as` as keyword for roles; this is a new field and a mapping addition.
+
+Exact principals only. No `*`, no `elastic/*`. A wildcard on the target would recreate the original hole on a different document.
+
+Direct bearer-token authentication is unchanged: holding a token does not require membership in `run_as_from`. Impersonation and credential possession stay separate. A disabled account is rejected as a run-as target the same way it fails authentication.
+
+PUT remains full replacement, as with `roles` and `enabled`. Updating roles without resending `run_as_from` clears it and drops impersonation. That is fail closed; the management UI must always send the field.
+
+#### Caller capability, not a name list
+
+The authenticating principal still needs permission to *ask*. Allow service accounts to initiate run-as on this path, but do not put a managed-namespace `run_as` pattern on `kibana_system`. Give `elastic/kibana` a capability: a dedicated cluster privilege (for example `run_as_managed_service_account`) on that account's built-in role, or an equivalent special case for that principal. That answers "is this principal allowed to attempt impersonation of managed accounts." The account's `run_as_from` answers "may they inhabit *this* account." Both checks must pass.
+
+`elastic/kibana` does not have `manage_security`, so it cannot write `run_as_from` and cannot opt itself into accounts. Consent is an admin mutation (the Kibana management UI runs as the logged-in admin); use is later impersonation by Task Manager with the Kibana service token. That split is the security property.
+
+An admin can still assign `superuser` *and* list `elastic/kibana`. That is explicit and per-account, the same class of decision as putting `run_as: ["elastic"]` on a human role, not an implicit cluster-wide grant.
+
+#### What this does not close
+
+Kibana can inhabit any opted-in account. If a non-admin Kibana user can bind an alerting rule to `acme/super-workflow`, Elasticsearch only sees `elastic/kibana` run-as that principal. Binding workloads to accounts is Kibana authorization. Encoding application identifiers (`on_behalf_of: alerting:rule:123`) into the account document would leak Kibana semantics into the security index and is out of scope here.
+
+Operator privileges already refuse to treat a run-as authentication as operator. Impersonation would drop operator status; that is existing behavior and the correct direction.
+
+#### Authorization checks
+
+Run-as target lookup today considers ordinary users only. For a name that parses as a managed service-account principal, resolve it as a managed account instead. Then:
+
+- deny if the account is missing or disabled;
+- deny if the authenticating principal is not in `run_as_from`;
+- deny if the caller lacks the initiator capability.
+
+The resulting authentication must be allowed to have a service-account effective identity; today run-as requires an ordinary user. Existing `run_as_granted` / `run_as_denied` audit events cover the outcome; the denial should distinguish caller-side vs target-side failure.
 
 ### Self-service account management (API key parity)
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -424,12 +424,13 @@ public final class Authentication implements ToXContentObject {
         );
     }
 
-    /** Returns a new {@code Authentication} for tokens created by the current {@code Authentication}, which is used when
-     * authenticating using the token credential.
+    /**
+     * Returns a new {@code Authentication} for tokens created by the current {@code Authentication}, which is used when
+     * authenticating using the token credential. Service-account and API key subjects are preserved as-is
+     * ({@link #isServiceAccount()} and {@link #isApiKey()} remain true).
      */
     public Authentication token() {
         assert false == isAuthenticatedInternally();
-        assert false == isServiceAccount();
         assert false == isCrossClusterAccess();
         final Authentication newTokenAuthentication = new Authentication(effectiveSubject, authenticatingSubject, AuthenticationType.TOKEN);
         return newTokenAuthentication;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -422,6 +422,16 @@ public class AuthenticationTests extends ESTestCase {
         assertCanAccessResources(original3, token3);
         assertCanAccessResources(original3, token3.token());
         assertCanAccessResources(token3, token3.token());
+
+        Authentication original4 = AuthenticationTestHelper.builder().serviceAccount().build(false);
+        Authentication token4 = original4.token();
+        assertThat(token4.isServiceAccount(), is(true));
+        assertCanAccessResources(original4, token4);
+        assertCanAccessResources(original4, token4.token());
+        assertCanAccessResources(token4, token4.token());
+        assertCannotAccessResources(original, token4);
+        assertCannotAccessResources(original2, token4);
+        assertCannotAccessResources(original3, token4);
     }
 
     public void testRunAsAccessResourceOf() {

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
@@ -100,6 +100,33 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
         }
     }
 
+    /**
+     * Service-account credentials work on a basic license, but minting an OAuth
+     * access token does not: the token service requires Standard or above.
+     * After a trial is started the same kibana service account (which has
+     * {@code manage_token}) can mint; after revert, minting is rejected again
+     * and a previously minted access token can no longer authenticate.
+     */
+    public void testServiceAccountOAuthMintingRequiresStandardLicense() throws Exception {
+        checkLicenseType("basic");
+        final String kibanaServiceToken = createServiceAccountToken("elastic", "kibana", "license-oauth-kibana");
+        assertAuthenticateWithServiceAccountToken(kibanaServiceToken, "elastic/kibana");
+        assertFailToGetToken(kibanaServiceToken);
+
+        startTrial();
+        String accessToken = null;
+        try {
+            checkLicenseType("trial");
+            accessToken = getAccessToken(kibanaServiceToken);
+            assertAuthenticateWithToken(accessToken, "elastic/kibana", true);
+        } finally {
+            revertTrial();
+            assertFailToGetToken(kibanaServiceToken);
+            assertAuthenticateWithServiceAccountToken(kibanaServiceToken, "elastic/kibana");
+            assertAuthenticateWithToken(accessToken, "elastic/kibana", false);
+        }
+    }
+
     private void startTrial() throws IOException {
         Response response = client().performRequest(new Request("POST", "/_license/start_trial?acknowledge=true"));
         assertOK(response);
@@ -214,6 +241,14 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
         return getToken;
     }
 
+    private Request buildClientCredentialsTokenRequest() {
+        final Request getToken = new Request("POST", "/_security/oauth2/token");
+        getToken.setJsonEntity("""
+            {"grant_type" : "client_credentials"}
+            """);
+        return getToken;
+    }
+
     private Request buildGetApiKeyRequest() {
         final Request getApiKey = new Request("POST", "/_security/api_key");
         getApiKey.setJsonEntity("""
@@ -231,6 +266,16 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
         return ObjectPath.evaluate(tokens, "access_token").toString();
     }
 
+    private String getAccessToken(String bearerString) throws IOException {
+        final Request request = buildClientCredentialsTokenRequest();
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + bearerString));
+        Response getTokenResponse = client().performRequest(request);
+        assertThat(getTokenResponse.getStatusLine().getStatusCode(), equalTo(200));
+        final Map<String, Object> tokens = entityAsMap(getTokenResponse);
+        assertNull(tokens.get("refresh_token"));
+        return ObjectPath.evaluate(tokens, "access_token").toString();
+    }
+
     private String getApiKeyCredentials() throws IOException {
         Response getApiKeyResponse = adminClient().performRequest(buildGetApiKeyRequest());
         assertThat(getApiKeyResponse.getStatusLine().getStatusCode(), equalTo(200));
@@ -245,7 +290,19 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
         assertThat(e.getMessage(), containsString("current license is non-compliant for [security tokens]"));
     }
 
+    private void assertFailToGetToken(String bearerString) {
+        final Request request = buildClientCredentialsTokenRequest();
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + bearerString));
+        ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(403));
+        assertThat(e.getMessage(), containsString("current license is non-compliant for [security tokens]"));
+    }
+
     private void assertAuthenticateWithToken(String accessToken, boolean shouldSucceed) throws IOException {
+        assertAuthenticateWithToken(accessToken, "security_test_user", shouldSucceed);
+    }
+
+    private void assertAuthenticateWithToken(String accessToken, String expectedUsername, boolean shouldSucceed) throws IOException {
         assertNotNull("access token cannot be null", accessToken);
         Request request = new Request("GET", "/_security/_authenticate");
         RequestOptions.Builder options = request.getOptions().toBuilder();
@@ -254,7 +311,7 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
         if (shouldSucceed) {
             Response authenticateResponse = client().performRequest(request);
             assertOK(authenticateResponse);
-            assertEquals("security_test_user", entityAsMap(authenticateResponse).get("username"));
+            assertEquals(expectedUsername, entityAsMap(authenticateResponse).get("username"));
         } else {
             ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
             assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(401));
@@ -283,7 +340,14 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
     }
 
     private String createServiceAccountToken() throws IOException {
-        final Request request = new Request("POST", "_security/service/elastic/fleet-server/credential/token/api-token-1");
+        return createServiceAccountToken("elastic", "fleet-server", "api-token-1");
+    }
+
+    private String createServiceAccountToken(String namespace, String service, String tokenName) throws IOException {
+        final Request request = new Request(
+            "POST",
+            Strings.format("_security/service/%s/%s/credential/token/%s", namespace, service, tokenName)
+        );
         final Response response = adminClient().performRequest(request);
         assertOK(response);
         @SuppressWarnings("unchecked")
@@ -292,11 +356,15 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
     }
 
     private void assertAuthenticateWithServiceAccountToken(String bearerString) throws IOException {
+        assertAuthenticateWithServiceAccountToken(bearerString, "elastic/fleet-server");
+    }
+
+    private void assertAuthenticateWithServiceAccountToken(String bearerString, String expectedUsername) throws IOException {
         Request request = new Request("GET", "/_security/_authenticate");
         request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Bearer " + bearerString));
         final Response response = client().performRequest(request);
         assertOK(response);
-        assertEquals("elastic/fleet-server", responseAsMap(response).get("username"));
+        assertEquals(expectedUsername, responseAsMap(response).get("username"));
     }
 
     private void assertAddRoleWithDLS(boolean shouldSucceed) throws IOException {

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -48,6 +48,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ServiceAccountIT extends ESRestTestCase {
@@ -579,6 +580,49 @@ public class ServiceAccountIT extends ESRestTestCase {
             """, refreshToken));
         final Response refreshTokenResponse = adminClient().performRequest(refreshTokenRequest);
         assertOK(refreshTokenResponse);
+    }
+
+    public void testServiceAccountWithoutManageTokenCannotMintOAuthToken() throws IOException {
+        final Request oauthTokenRequest = new Request("POST", "_security/oauth2/token");
+        oauthTokenRequest.setJsonEntity("{\"grant_type\":\"client_credentials\"}");
+        oauthTokenRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Bearer " + VALID_SERVICE_TOKEN));
+        final ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(oauthTokenRequest));
+        assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(403));
+        assertThat(e.getMessage(), containsString("unauthorized"));
+        assertThat(e.getMessage(), not(containsString("OAuth2 token creation is not supported for service accounts")));
+    }
+
+    public void testKibanaServiceAccountCanMintOAuthToken() throws IOException {
+        final Request createServiceTokenRequest = new Request("POST", "_security/service/elastic/kibana/credential/token/oauth-token-1");
+        final Response createServiceTokenResponse = client().performRequest(createServiceTokenRequest);
+        assertOK(createServiceTokenResponse);
+        @SuppressWarnings("unchecked")
+        final Map<String, String> serviceTokenMap = (Map<String, String>) responseAsMap(createServiceTokenResponse).get("token");
+        final String serviceToken = serviceTokenMap.get("value");
+
+        final Request oauthTokenRequest = new Request("POST", "_security/oauth2/token");
+        oauthTokenRequest.setJsonEntity("{\"grant_type\":\"client_credentials\"}");
+        oauthTokenRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Bearer " + serviceToken));
+        final Response oauthTokenResponse = client().performRequest(oauthTokenRequest);
+        assertOK(oauthTokenResponse);
+        final Map<String, Object> oauthTokenResponseMap = responseAsMap(oauthTokenResponse);
+        final String accessToken = (String) oauthTokenResponseMap.get("access_token");
+        assertThat(accessToken, not(nullValue()));
+        assertThat(oauthTokenResponseMap.get("expires_in"), not(nullValue()));
+        assertThat(oauthTokenResponseMap.get("refresh_token"), nullValue());
+
+        final Request authenticateRequest = new Request("GET", "_security/_authenticate");
+        authenticateRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Bearer " + accessToken));
+        final Response authenticateResponse = client().performRequest(authenticateRequest);
+        assertOK(authenticateResponse);
+        final Map<String, Object> authenticateMap = responseAsMap(authenticateResponse);
+        assertThat(authenticateMap.get("username"), equalTo("elastic/kibana"));
+        assertThat(authenticateMap.get("authentication_type"), equalTo("token"));
+        assertThat(authenticateMap.get("metadata"), equalTo(Map.of("_elastic_service_account", true)));
+        assertThat(
+            authenticateMap.get("token"),
+            equalTo(Map.of("name", "oauth-token-1", "type", "_service_account_index", "managed_by", "elasticsearch"))
+        );
     }
 
     public void testAuthenticateShouldDifferentiateBetweenNormalUserAndServiceAccount() throws IOException {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ManagedServiceAccountSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ManagedServiceAccountSingleNodeTests.java
@@ -34,6 +34,8 @@ import org.elasticsearch.xpack.core.security.action.service.PutManagedServiceAcc
 import org.elasticsearch.xpack.core.security.action.service.PutManagedServiceAccountResponse;
 import org.elasticsearch.xpack.core.security.action.service.ServiceAccountInfo;
 import org.elasticsearch.xpack.core.security.action.service.ServiceAccountManagedBy;
+import org.elasticsearch.xpack.core.security.action.token.CreateTokenRequestBuilder;
+import org.elasticsearch.xpack.core.security.action.token.CreateTokenResponse;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateAction;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateRequest;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateResponse;
@@ -62,7 +64,9 @@ import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class ManagedServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
 
@@ -71,6 +75,7 @@ public class ManagedServiceAccountSingleNodeTests extends SecuritySingleNodeTest
     private static final String MONITOR_ROLE = "managed_sa_monitor_role";
     private static final String API_KEY_ROLE = "managed_sa_api_key_role";
     private static final String GRANT_API_KEY_ROLE = "managed_sa_grant_api_key_role";
+    private static final String MANAGE_TOKEN_ROLE = "managed_sa_manage_token_role";
 
     private String serviceName;
     private String principal;
@@ -105,7 +110,12 @@ public class ManagedServiceAccountSingleNodeTests extends SecuritySingleNodeTest
             + GRANT_API_KEY_ROLE
             + ":\n"
             + "  cluster:\n"
-            + "    - 'grant_api_key'\n";
+            + "    - 'grant_api_key'\n"
+            + MANAGE_TOKEN_ROLE
+            + ":\n"
+            + "  cluster:\n"
+            + "    - 'manage_token'\n"
+            + "    - 'monitor'\n";
     }
 
     @Override
@@ -292,6 +302,38 @@ public class ManagedServiceAccountSingleNodeTests extends SecuritySingleNodeTest
 
         final SecureString newBearer = createManagedToken("token-after-recreate");
         authenticate(newBearer.toString());
+    }
+
+    public void testMintOAuthAccessTokenWithManageTokenPrivilege() {
+        putManagedAccount(MANAGE_TOKEN_ROLE);
+        final SecureString serviceToken = createManagedToken("token-oauth");
+
+        final CreateTokenResponse createTokenResponse = new CreateTokenRequestBuilder(bearerClient(serviceToken.toString())).setGrantType(
+            "client_credentials"
+        ).get();
+        assertThat(createTokenResponse.getTokenString(), notNullValue());
+        assertThat(createTokenResponse.getExpiresIn(), notNullValue());
+        assertThat(createTokenResponse.getRefreshToken(), nullValue());
+
+        final Authentication oauthAuthentication = authenticate(createTokenResponse.getTokenString());
+        assertThat(oauthAuthentication.isServiceAccount(), is(true));
+        assertThat(oauthAuthentication.isManagedServiceAccount(), is(true));
+        assertThat(oauthAuthentication.getEffectiveSubject().getUser().principal(), equalTo(principal));
+        assertThat(oauthAuthentication.getEffectiveSubject().getUser().roles(), arrayContainingInAnyOrder(MANAGE_TOKEN_ROLE));
+        assertHasClusterPrivilege(createTokenResponse.getTokenString(), "monitor", true);
+    }
+
+    public void testMintOAuthAccessTokenRequiresManageTokenPrivilege() {
+        putManagedAccount(MONITOR_ROLE);
+        final SecureString serviceToken = createManagedToken("token-no-oauth");
+
+        final ElasticsearchSecurityException exception = expectThrows(
+            ElasticsearchSecurityException.class,
+            () -> new CreateTokenRequestBuilder(bearerClient(serviceToken.toString())).setGrantType("client_credentials").get()
+        );
+        assertThat(exception.status(), equalTo(RestStatus.FORBIDDEN));
+        assertThat(exception.getMessage(), containsString("unauthorized"));
+        assertThat(exception.getMessage(), not(containsString("OAuth2 token creation is not supported for service accounts")));
     }
 
     private Client securityAdminClient() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountSingleNodeTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.security.authc.service;
 
+import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
@@ -15,6 +16,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.SecuritySingleNodeTestCase;
 import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheAction;
 import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheRequest;
@@ -25,10 +27,13 @@ import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccount
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenAction;
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenResponse;
+import org.elasticsearch.xpack.core.security.action.token.CreateTokenRequestBuilder;
+import org.elasticsearch.xpack.core.security.action.token.CreateTokenResponse;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateAction;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateRequest;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateResponse;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.user.User;
 
 import java.util.Map;
@@ -37,8 +42,12 @@ import static org.elasticsearch.test.SecuritySettingsSource.TEST_PASSWORD_HASHED
 import static org.elasticsearch.test.SecuritySettingsSource.addSSLSettingsForNodePEMFiles;
 import static org.elasticsearch.test.SecuritySettingsSourceField.TEST_PASSWORD;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
 
@@ -153,6 +162,53 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
         client().execute(ClearSecurityCacheAction.INSTANCE, clearSecurityCacheRequest2, future2);
         assertThat(future2.actionGet().failures().isEmpty(), is(true));
         assertThat(cache.count(), equalTo(1));
+    }
+
+    public void testKibanaServiceAccountCanMintOAuthAccessToken() {
+        final CreateServiceAccountTokenRequest createServiceTokenRequest = new CreateServiceAccountTokenRequest(
+            "elastic",
+            "kibana",
+            "oauth-token-1"
+        );
+        final CreateServiceAccountTokenResponse createServiceTokenResponse = createServiceAccountManagerClient().execute(
+            CreateServiceAccountTokenAction.INSTANCE,
+            createServiceTokenRequest
+        ).actionGet();
+        final String serviceToken = createServiceTokenResponse.getValue().toString();
+
+        final CreateTokenResponse createTokenResponse = new CreateTokenRequestBuilder(createServiceAccountClient(serviceToken))
+            .setGrantType("client_credentials")
+            .get();
+        assertThat(createTokenResponse.getTokenString(), notNullValue());
+        assertThat(createTokenResponse.getExpiresIn(), notNullValue());
+        assertThat(createTokenResponse.getRefreshToken(), nullValue());
+
+        final AuthenticateResponse authenticateResponse = createServiceAccountClient(createTokenResponse.getTokenString()).execute(
+            AuthenticateAction.INSTANCE,
+            AuthenticateRequest.INSTANCE
+        ).actionGet();
+        final Authentication authentication = authenticateResponse.authentication();
+        assertThat(authentication.isServiceAccount(), is(true));
+        assertThat(authentication.isBuiltInServiceAccount(), is(true));
+        assertThat(authentication.getEffectiveSubject().getUser().principal(), equalTo("elastic/kibana"));
+        assertThat(
+            authentication.getAuthenticatingSubject().getMetadata().get(ServiceAccountSettings.TOKEN_NAME_FIELD),
+            equalTo("oauth-token-1")
+        );
+        assertThat(
+            authentication.getAuthenticatingSubject().getMetadata().get(ServiceAccountSettings.TOKEN_SOURCE_FIELD),
+            equalTo("index")
+        );
+    }
+
+    public void testFleetServerServiceAccountCannotMintOAuthAccessToken() {
+        final ElasticsearchSecurityException exception = expectThrows(
+            ElasticsearchSecurityException.class,
+            () -> new CreateTokenRequestBuilder(createServiceAccountClient()).setGrantType("client_credentials").get()
+        );
+        assertThat(exception.status(), equalTo(RestStatus.FORBIDDEN));
+        assertThat(exception.getMessage(), containsString("unauthorized"));
+        assertThat(exception.getMessage(), not(containsString("OAuth2 token creation is not supported for service accounts")));
     }
 
     private Client createServiceAccountManagerClient() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.security.action.token;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -73,11 +72,6 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
             case PASSWORD, KERBEROS -> authenticateAndCreateToken(type, request, listener);
             case CLIENT_CREDENTIALS -> {
                 Authentication authentication = securityContext.getAuthentication();
-                if (authentication.isServiceAccount()) {
-                    // Service account itself cannot create OAuth2 tokens.
-                    listener.onFailure(new ElasticsearchException("OAuth2 token creation is not supported for service accounts"));
-                    return;
-                }
                 createToken(type, request, authentication, authentication, false, listener);
             }
             default -> listener.onFailure(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -339,7 +339,8 @@ public class TokenService {
      *                                for versions after {@link #VERSION_TOKENS_INDEX_INTRODUCED}</li>
      *                              </ul>
      * @param tokenVersion          The version of the nodes with which these tokens will be compatible.
-     * @param authentication        The authentication object representing the user for which the tokens are created
+     * @param authentication        The authentication object representing the user for which the tokens are created.
+     *                              Service-account subjects are stored as-is (same as API keys).
      * @param originatingClientAuth The authentication object representing the client that called the related API
      * @param metadata              A map with metadata to be stored in the token document
      * @param listener              The listener to call upon completion with a {@link CreateTokenResult} containing the

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.security.action.token;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetRequestBuilder;
@@ -394,7 +393,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         Mockito.verifyNoMoreInteractions(authenticationService);
     }
 
-    public void testServiceAccountCannotCreateOAuthToken() throws Exception {
+    public void testServiceAccountCreatesOAuthTokenWithoutRefreshToken() throws Exception {
         final TokenService tokenService = new TokenService(
             SETTINGS,
             Clock.systemUTC(),
@@ -420,10 +419,17 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         final CreateTokenRequest createTokenRequest = new CreateTokenRequest();
         createTokenRequest.setGrantType("client_credentials");
 
-        PlainActionFuture<CreateTokenResponse> future = new PlainActionFuture<>();
-        action.doExecute(null, createTokenRequest, future);
-        final ElasticsearchException e = expectThrows(ElasticsearchException.class, future::actionGet);
-        assertThat(e.getMessage(), containsString("OAuth2 token creation is not supported for service accounts"));
+        PlainActionFuture<CreateTokenResponse> tokenResponseFuture = new PlainActionFuture<>();
+        action.doExecute(null, createTokenRequest, tokenResponseFuture);
+        CreateTokenResponse createTokenResponse = tokenResponseFuture.get();
+        assertNull(createTokenResponse.getRefreshToken());
+        assertNotNull(createTokenResponse.getTokenString());
+
+        assertNotNull(idxReqReference.get());
+        Map<String, Object> sourceMap = idxReqReference.get().sourceAsMap();
+        assertNotNull(sourceMap);
+        assertNotNull(sourceMap.get("access_token"));
+        assertNull(sourceMap.get("refresh_token"));
     }
 
     private static <T> ActionListener<T> assertListenerIsOnlyCalledOnce(ActionListener<T> delegate) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -80,6 +80,7 @@ import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTests;
+import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.authc.support.TokensInvalidationResult;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
@@ -336,6 +337,51 @@ public class TokenServiceTests extends ESTestCase {
             anotherService.tryAuthenticateToken(bearerToken, future);
             UserToken fromOtherService = future.get();
             assertAuthentication(authentication, fromOtherService.getAuthentication());
+        }
+    }
+
+    public void testCreateAndAuthenticateServiceAccountOAuth2Token() throws Exception {
+        TokenService tokenService = createTokenService(tokenServiceEnabledSettings, systemUTC());
+        Authentication authentication = AuthenticationTestHelper.builder().serviceAccount().build(false);
+        assertThat(authentication.isServiceAccount(), is(true));
+        PlainActionFuture<TokenService.CreateTokenResult> tokenFuture = new PlainActionFuture<>();
+        Tuple<byte[], byte[]> newTokenBytes = tokenService.getRandomTokenBytes(false);
+        tokenService.createOAuth2Tokens(
+            newTokenBytes.v1(),
+            newTokenBytes.v2(),
+            authentication,
+            authentication,
+            Collections.emptyMap(),
+            tokenFuture
+        );
+        final String accessToken = tokenFuture.get().getAccessToken();
+        assertNotNull(accessToken);
+        assertNull(tokenFuture.get().getRefreshToken());
+        mockGetTokenFromAccessTokenBytes(tokenService, newTokenBytes.v1(), authentication, false, null);
+
+        ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
+        requestContext.putHeader("Authorization", randomFrom("Bearer ", "BEARER ", "bearer ") + accessToken);
+
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
+            PlainActionFuture<UserToken> future = new PlainActionFuture<>();
+            final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
+            tokenService.tryAuthenticateToken(bearerToken, future);
+            UserToken serialized = future.get();
+            Authentication recovered = serialized.getAuthentication();
+            assertThat(recovered.isServiceAccount(), is(true));
+            assertThat(
+                recovered.getEffectiveSubject().getUser().principal(),
+                equalTo(authentication.getEffectiveSubject().getUser().principal())
+            );
+            assertThat(
+                recovered.getAuthenticatingSubject().getMetadata().get(ServiceAccountSettings.TOKEN_NAME_FIELD),
+                equalTo(authentication.getAuthenticatingSubject().getMetadata().get(ServiceAccountSettings.TOKEN_NAME_FIELD))
+            );
+            assertThat(
+                recovered.getAuthenticatingSubject().getMetadata().get(ServiceAccountSettings.TOKEN_SOURCE_FIELD),
+                equalTo(authentication.getAuthenticatingSubject().getMetadata().get(ServiceAccountSettings.TOKEN_SOURCE_FIELD))
+            );
+            assertAuthentication(authentication, recovered);
         }
     }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/20_managed.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/20_managed.yml
@@ -31,6 +31,14 @@ setup:
             "cluster": ["manage_own_api_key"]
           }
 
+  - do:
+      security.put_role:
+        name: "managed_yaml_manage_token"
+        body: >
+          {
+            "cluster": ["manage_token", "monitor"]
+          }
+
 ---
 teardown:
   - do:
@@ -48,6 +56,20 @@ teardown:
         ignore: 404
 
   - do:
+      security.delete_service_token:
+        namespace: yaml_poc
+        service: worker_oauth
+        name: token-oauth
+        ignore: 404
+
+  - do:
+      security.delete_managed_service_account:
+        namespace: yaml_poc
+        service: worker_oauth
+        force: true
+        ignore: 404
+
+  - do:
       security.delete_managed_service_account:
         namespace: yaml_poc
         service: worker_1
@@ -62,6 +84,11 @@ teardown:
   - do:
       security.delete_role:
         name: "managed_yaml_api_key"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "managed_yaml_manage_token"
         ignore: 404
 
 ---
@@ -225,3 +252,49 @@ teardown:
         Authorization: Bearer ${managed_service_token_recreated}
       security.authenticate: {}
   - match: { username: "yaml_poc/worker_1" }
+
+---
+"Test managed service account can mint an OAuth access token":
+  - do:
+      security.put_managed_service_account:
+        namespace: yaml_poc
+        service: worker_oauth
+        body: >
+          {
+            "roles": ["managed_yaml_manage_token"],
+            "enabled": true
+          }
+  - match: { created: true }
+
+  - do:
+      security.create_service_token:
+        namespace: yaml_poc
+        service: worker_oauth
+        name: token-oauth
+  - is_true: created
+  - set: { "token.value": managed_oauth_service_token }
+
+  - do:
+      headers:
+        Authorization: Bearer ${managed_oauth_service_token}
+      security.get_token:
+        body:
+          grant_type: "client_credentials"
+
+  - match: { type: "Bearer" }
+  - is_true: access_token
+  - set: { access_token: managed_oauth_access_token }
+  - match: { expires_in: 1200 }
+  - is_false: refresh_token
+
+  - do:
+      headers:
+        Authorization: Bearer ${managed_oauth_access_token}
+      security.authenticate: {}
+
+  - match: { username: "yaml_poc/worker_oauth" }
+  - match: { authentication_type: "token" }
+  - match: { roles: ["managed_yaml_manage_token"] }
+  - match: { metadata._managed_service_account: true }
+  - match: { "token.name": "token-oauth" }
+  - match: { "token.type": "_service_account_index" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/30_oauth_token.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/30_oauth_token.yml
@@ -1,0 +1,81 @@
+---
+setup:
+  - skip:
+      features: headers
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+teardown:
+  - do:
+      security.delete_service_token:
+        namespace: elastic
+        service: kibana
+        name: oauth-token-kibana
+        ignore: 404
+
+  - do:
+      security.delete_service_token:
+        namespace: elastic
+        service: fleet-server
+        name: oauth-token-fleet
+        ignore: 404
+
+---
+"Test kibana service account can mint an OAuth access token":
+  - do:
+      security.create_service_token:
+        namespace: elastic
+        service: kibana
+        name: oauth-token-kibana
+
+  - is_true: created
+  - match: { "token.name": "oauth-token-kibana" }
+  - set: { "token.value": service_token_kibana }
+
+  - do:
+      headers:
+        Authorization: Bearer ${service_token_kibana}
+      security.get_token:
+        body:
+          grant_type: "client_credentials"
+
+  - match: { type: "Bearer" }
+  - is_true: access_token
+  - set: { access_token: oauth_access_token }
+  - match: { expires_in: 1200 }
+  - is_false: refresh_token
+
+  - do:
+      headers:
+        Authorization: Bearer ${oauth_access_token}
+      security.authenticate: {}
+
+  - match: { username: "elastic/kibana" }
+  - match: { authentication_type: "token" }
+  - match: { metadata._elastic_service_account: true }
+  - match: { "token.name": "oauth-token-kibana" }
+  - match: { "token.type": "_service_account_index" }
+
+---
+"Test fleet-server service account cannot mint an OAuth access token":
+  - do:
+      security.create_service_token:
+        namespace: elastic
+        service: fleet-server
+        name: oauth-token-fleet
+
+  - is_true: created
+  - set: { "token.value": service_token_fleet }
+
+  - do:
+      catch: forbidden
+      headers:
+        Authorization: Bearer ${service_token_fleet}
+      security.get_token:
+        body:
+          grant_type: "client_credentials"
+
+  - match: { "error.type": "security_exception" }


### PR DESCRIPTION
## Summary
- Service accounts can mint OAuth access tokens via client_credentials. The token service was already generic; this removes the two hard rejects (TransportCreateTokenAction and Authentication.token()).
- The minted token stays TOKEN authentication of a SERVICE_ACCOUNT subject, same identity model as API keys. Authorization is still manage_token, no refresh token is issued, and the token service remains Standard+.
- _authenticate still reports the originating service token metadata, so a service token and a minted OAuth token look the same there.

## Test plan
- [ ] Unit: Authentication.token() canAccessResources, TransportCreateTokenAction client_credentials, TokenService mint and authenticate
- [ ] Single-node: kibana and managed SA with manage_token succeed; fleet-server and managed SA without manage_token get 403
- [ ] Java REST: ServiceAccountIT kibana mint and fleet-server forbidden
- [ ] YAML: 30_oauth_token.yml and managed SA mint in 20_managed.yml
- [ ] Basic license: kibana can authenticate with its service token but cannot mint until trial; after revert, minting fails again and the minted access token cannot authenticate